### PR TITLE
Add owner permission modifier

### DIFF
--- a/src/JBOwnableOverrides.sol
+++ b/src/JBOwnableOverrides.sol
@@ -95,6 +95,24 @@ abstract contract JBOwnableOverrides is Context, IJBOwnable, IJBOperatable {
         _;
     }
 
+     /** 
+        @notice
+        Only allows callers that have received permission from the projectOwner for this project.
+
+        @param _permissionIndex The index of the permission to check for. 
+    */
+    modifier requirePermissionFromOwner(
+        uint256 _permissionIndex
+    ) {
+        JBOwner memory _ownerData = jbOwner;
+
+        address _owner = _ownerData.projectId == 0 ?
+         _ownerData.owner : projects.ownerOf(_ownerData.projectId);
+
+        _requirePermission(_owner, _ownerData.projectId, _permissionIndex);
+        _;
+    }
+
     /** 
         @notice
         Only allows the speficied account, an operator of the account to proceed, or a truthy override flag. 

--- a/test/mocks/MockOwnable.sol
+++ b/test/mocks/MockOwnable.sol
@@ -6,6 +6,12 @@ import {JBOwnable, IJBProjects, IJBOperatorStore, JBOwnableOverrides} from "../.
 contract MockOwnable is JBOwnable {
     event ProtectedMethodCalled();
 
+    uint256 permission;
+
+    function setPermission(uint256 _permission) external {
+        permission = _permission;
+    }
+
     constructor(
         IJBProjects _projects,
         IJBOperatorStore _operatorStore
@@ -13,6 +19,10 @@ contract MockOwnable is JBOwnable {
 
 
     function protectedMethod() external onlyOwner {
+        emit ProtectedMethodCalled();
+    }
+
+    function protectedMethodWithRequirePermission() external requirePermissionFromOwner(permission) {
         emit ProtectedMethodCalled();
     }
 }


### PR DESCRIPTION
Added a modifier that checks if the caller has received a specific permission from the project owner for the project domain. This modifier only does a single sload instead of the 2 sloads required if you do  
`requirePermission(owner(), jbOwner.projectId, _permissionIndex)`